### PR TITLE
kernel_patch_verify: do not generate cover-letter

### DIFF
--- a/kernel_patch_verify
+++ b/kernel_patch_verify
@@ -719,7 +719,7 @@ chmod +x $SMATCH
 
 # First create a list of patches to test..
 if [ -n "$TEST_TOP" ]; then
-	git format-patch -M -C -o $PATCHD -1 >/dev/null
+	git format-patch --no-cover-letter -M -C -o $PATCHD -1 >/dev/null
 	git checkout -b $TEST_BRANCH_NAME
 	git reset --hard HEAD^
 fi
@@ -730,7 +730,7 @@ if [ -n "$PATCHES" ]; then
 fi
 
 if [ -n "$TEST_BRANCH" ]; then
-	git format-patch -M -C -o $PATCHD $BASE_BRANCH..$TEST_BRANCH >/dev/null
+	git format-patch --no-cover-letter -M -C -o $PATCHD $BASE_BRANCH..$TEST_BRANCH >/dev/null
 	PATCHES=`realpath $PATCHD/*.patch|grep -v "$COVER_LETTER"`
 	PATCHCOUNT=`ls $PATCHES|wc -l`
 	if [ $PATCHCOUNT -eq 0 ]; then


### PR DESCRIPTION
Do not generate cover-letter when generating patches
to verify. That patch cannot be applied and leaves
an unfinished git-am. This can happen if generating
cover-letter is default in user's git configuration.

Signed-off-by: Sekhar Nori <nsekhar@ti.com>