### PR TITLE
kernel_patch_verify: switch to using olddefconfig

### DIFF
--- a/kernel_patch_verify
+++ b/kernel_patch_verify
@@ -194,7 +194,7 @@ defconfig() {
 		kmake $DEFCONFIG >/dev/null
 	else
 		cp $TEST_DIR/.config .config
-		kmake oldconfig >/dev/null
+		kmake olddefconfig >/dev/null
 	fi
 }
 
@@ -560,7 +560,7 @@ usage() {
 	echo -e "\t-T temp_dir_base: temporary directory base (default is $DEFAULT_TMPDIR)" >&2
 	echo -e "\t-l logfile: report file (defaults to $DEFAULT_LOG)" >&2
 	echo -e "\t-C: run Complete tests(WARNING: could take significant time!)" >&2
-	echo -e "\t-c defconfig:_name (default uses current .config + oldconfig)" >&2
+	echo -e "\t-c defconfig:_name (default uses current .config + olddefconfig)" >&2
 	echo -e "\t-[1..9]: test the tip of current branch (1 to 9 number of patches)" >&2
 	echo -e "\t-n N: test the tip of current branch with 'N' number of patches" >&2
 	echo -e "\t-p patch_dir: which directory to take patches from (expects sorted in order)" >&2


### PR DESCRIPTION
When a patch results in a change in kernel configuration
such that a config variable needs to have a new value,
'make oldconfig' will wait for user to provide input for
that new config.

This makes the 'kernel_patch_verify' appear hung at the
defconfig step (since command output is also redirected).
The build proceeds further only when user presses return
key, for example.

Fix this by switching to olddefconfig instead, which is
non-interactive and starts using the default answers to
new config questions.

Signed-off-by: Sekhar Nori <nsekhar@ti.com>