### PR TITLE
kernel_patch_verify: Remove unintended '$' character in cover-letter

### DIFF
--- a/kernel_patch_verify
+++ b/kernel_patch_verify
@@ -52,7 +52,7 @@ DEF_CPUS=`grep -c '^processor' /proc/cpuinfo`
 DEFAULT_LOG="./report-kernel-patch-verify.txt"
 DEFAULT_TMPDIR="/tmp"
 
-COVER_LETTER="cover-letter.[patch\|diff]$"
+COVER_LETTER="cover-letter.[patch\|diff]"
 
 LINE_LENGTH=100
 


### PR DESCRIPTION
Remove the unintended '$' character in the cover-letter string.

Fixes: 123773531ed7 ("kernel_patch_verify: allow .diff suffix")
Signed-off-by: Aswath Govindraju <a-govindraju@ti.com>